### PR TITLE
[aae-export] Merge Power Pin functionality into aae-export.py

### DIFF
--- a/doc/templaters.md
+++ b/doc/templaters.md
@@ -64,11 +64,13 @@ It contains
 For every line marked `kara` with the same style as this line, it will generate a line with the text of the kara line, without the k-timing tags.
 These outputted lines will be marked `fx` so that they can be deleted or replaced later.*
 
-This already highlights some differences between templaters:
+Note that different templaters use slightly different keywords for some of these markers:
 | Concept | In Stock Templater | In KaraOK | In The0x's Templater |
 | ---- | ------------------ | --------- | -------------------- |
 | Karaoke line marker | `karaoke` | `karaoke` | `kara` or `karaoke` |
 | Template applying tags once to each line | `template pre-line` | `template line` | `template line` |
+
+This is the beginning of a larger list of differences between templaters. The [tables](#comparison) at the bottom of this guide show the full list of differences.
 
 *Next, try to write `{\fad(150,150)}` into the text of the `template line` line, and apply the template.
 This will give every generated `fx` line these fade tags. So we've already built a worse version of HYDRA using karaoke templates.*

--- a/scripts/aae-export.py
+++ b/scripts/aae-export.py
@@ -265,6 +265,10 @@ class AAEExport(bpy.types.Panel):
     def draw(self, context):
         pass
 
+    @classmethod
+    def poll(cls, context):
+        return context.edit_movieclip is not None
+
 class AAEExportSelectedTrack(bpy.types.Panel):
     bl_label = "Selected track"
     bl_idname = "SOLVE_PT_aae_export_selected"
@@ -301,6 +305,10 @@ class AAEExportSelectedTrack(bpy.types.Panel):
         row.enabled = selected_plane_tracks == 1
         row.operator("movieclip.aae_export_copy_plane_track")
 
+    @classmethod
+    def poll(cls, context):
+        return context.edit_movieclip is not None
+
 class AAEExportAllTracks(bpy.types.Panel):
     bl_label = "All tracks"
     bl_idname = "SOLVE_PT_aae_export_all"
@@ -325,6 +333,10 @@ class AAEExportAllTracks(bpy.types.Panel):
         row.scale_y = 2
         row.enabled = len(context.edit_movieclip.tracking.tracks) >= 1
         row.operator("movieclip.aae_export_export_all")
+
+    @classmethod
+    def poll(cls, context):
+        return context.edit_movieclip is not None
 
 class AAEExportLegacy(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
     """Export motion tracking markers to Adobe After Effects 6.0 compatible files"""

--- a/scripts/aae-export.py
+++ b/scripts/aae-export.py
@@ -1,16 +1,48 @@
+# Function AAEExportExportAll._generate() at or about line 144,
+# excluding inner function generate_power_pin() at or about line 252,
+# is copied from the original `aae-export.py` by Martin Herkt.
+
+# Other part of this script, including the aforementioned inner
+# function generate_power_pin(), is written by arch1t3cht,
+# Akatsumekusa and contributors.
+
 # Copyright (c) 2013, Martin Herkt
 #
-# Permission to use, copy, modify, and/or distribute this software for any
-# purpose with or without fee is hereby granted, provided that the above
-# copyright notice and this permission notice appear in all copies.
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all
+# copies.
 #
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-# AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-# INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-# LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
-# OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+# DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+# PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+# TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 # PERFORMANCE OF THIS SOFTWARE.
+
+# Copyright (c) 2022 arch1t3cht and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+# 
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 bl_info = {
     "name": "Adobe After Effects 6.0 Keyframe Data Export",
@@ -218,7 +250,7 @@ class AAEExportExportAll(bpy.types.Operator):
         aae += rotations
 
         def generate_power_pin(clip, track):
-            power_pin = "\n"
+            power_pin = ""
 
             frames = []
             corners = []
@@ -232,14 +264,14 @@ class AAEExportExportAll(bpy.types.Operator):
                 corners.append([list(c) for c in marker.corners])
             
             for pini, corneri in [(2, 3), (3, 2), (4, 0), (5, 1)]:
-                power_pin += f"\nEffects\tCC Power Pin #1\tCC Power Pin-000{pini}\n"
-                power_pin += "\tFrame\tX pixels\tY pixels\n"
+                power_pin += f"\n\nEffects\tCC Power Pin #1\tCC Power Pin-000{pini}"
+                power_pin += "\n\tFrame\tX pixels\tY pixels"
 
                 for i, plane in enumerate(corners):
                     corner = plane[corneri]
                     x = corner[0] * clip.size[0]
                     y = (1 - corner[1]) * clip.size[1]
-                    power_pin += f"\t{frames[i]}\t{x:.3f}\t{y:.3f}\n"
+                    power_pin += f"\n\t{frames[i]}\t{x:.3f}\t{y:.3f}"
 
             return power_pin
     

--- a/scripts/aae-export.py
+++ b/scripts/aae-export.py
@@ -13,163 +13,367 @@
 # PERFORMANCE OF THIS SOFTWARE.
 
 bl_info = {
-    "name": "Export: Adobe After Effects 6.0 Keyframe Data",
-    "description": "Export motion tracking markers to Adobe After Effects 6.0 compatible files",
-    "author": "Martin Herkt",
-    "version": (0, 1, 5),
+    "name": "Adobe After Effects 6.0 Keyframe Data Export",
+    "description": "Export motion tracking data as Aegisub-Motion compatible AAE file",
+    "author": "Martin Herkt, arch1t3cht, Akatsumekusa",
+    "version": (0, 1, 6),
+    "support": "COMMUNITY",
+    "category": "Video Tools",
     "blender": (2, 80, 0),
-    "location": "File > Export > Adobe After Effects 6.0 Keyframe Data",
+    "location": "Clip Editor > Tools > Solve > AAE Export",
     "warning": "",
-    "category": "Import-Export",
-    }
+    "doc_url": "https://github.com/arch1t3cht/Aegisub-Scripts#other-scripts",
+    "tracker_url": "https://github.com/arch1t3cht/Aegisub-Scripts/issues"
+}
 
-import itertools
-import bpy, mathutils, math
+import bpy
+import bpy_extras.io_utils
+from datetime import datetime
+import math, mathutils
+from pathlib import Path
 
-def coords_corners_from_marker(marker):
-    if marker.__class__.__name__ == "MovieTrackingMarker":
-        return marker.co, marker.pattern_corners
-    elif marker.__class__.__name__ == "MovieTrackingPlaneMarker":
-        c = marker.corners
-        center = mathutils.geometry.intersect_line_line_2d(c[0], c[2], c[1], c[3])
-        return center, [mathutils.Vector(p) - center for p in c]
+class AAEExportSettings(bpy.types.PropertyGroup):
+    bl_label = "AAEExportSettings"
+    bl_idname = "AAEExportSettings"
+    
+    do_also_export: bpy.props.BoolProperty(name="Auto export",
+                                           description="Automatically export the selected track to file while copying",
+                                           default=True)
+    do_do_not_overwrite: bpy.props.BoolProperty(name="Do not overwrite",
+                                                description="Generate unique files every time",
+                                                default=False)
 
-
-def write_files(prefix, context):
-    scene = context.scene
-    fps = scene.render.fps / scene.render.fps_base
-
-    for clipno, clip in enumerate(bpy.data.movieclips):
-        for trackno, track in itertools.chain(enumerate(clip.tracking.tracks), enumerate(clip.tracking.plane_tracks)):
-            with open("{0}_c{1:02d}_{3}{2:02d}.txt".format(prefix, clipno, trackno, "planetrack" if track.__class__.__name__ == "MovieTrackingPlaneTrack" else "t"), "w") as f:
-
-                frameno = clip.frame_start
-                startarea = None
-                startwidth = None
-                startheight = None
-                startrot = None
-
-                data = []
-				
-                f.write("Adobe After Effects 6.0 Keyframe Data\r\n\r\n")
-                f.write("\tUnits Per Second\t{0:.3f}\r\n".format(fps))
-                f.write("\tSource Width\t{0}\r\n".format(clip.size[0]))
-                f.write("\tSource Height\t{0}\r\n".format(clip.size[1]))
-                f.write("\tSource Pixel Aspect Ratio\t1\r\n")
-                f.write("\tComp Pixel Aspect Ratio\t1\r\n\r\n")
-
-                while frameno <= clip.frame_duration:
-                    marker = track.markers.find_frame(frameno)
-                    frameno += 1
-
-                    if not marker or marker.mute:
-                        continue
-
-                    coords, corners = coords_corners_from_marker(marker)
-
-                    area = 0
-                    width = math.sqrt((corners[1][0] - corners[0][0]) * (corners[1][0] - corners[0][0]) + (corners[1][1] - corners[0][1]) * (corners[1][1] - corners[0][1]))
-                    height = math.sqrt((corners[3][0] - corners[0][0]) * (corners[3][0] - corners[0][0]) + (corners[3][1] - corners[0][1]) * (corners[3][1] - corners[0][1]))
-                    for i in range(1,3):
-                        x1 = corners[i][0] - corners[0][0]
-                        y1 = corners[i][1] - corners[0][1]
-                        x2 = corners[i+1][0] - corners[0][0]
-                        y2 = corners[i+1][1] - corners[0][1]
-                        area += x1 * y2 - x2 * y1
-
-                    area = abs(area / 2)
-
-                    if startarea == None:
-                        startarea = area
-
-                    if startwidth == None:
-                        startwidth = width
-                    if startheight == None:
-                        startheight = height
-
-                    zoom = math.sqrt(area / startarea) * 100
-
-                    xscale = width / startwidth * 100
-                    yscale = height / startheight * 100
-
-                    p1 = mathutils.Vector(corners[0])
-                    p2 = mathutils.Vector(corners[1])
-                    mid = (p1 + p2) / 2
-                    diff = mid - mathutils.Vector((0,0))
-
-                    rotation = math.atan2(diff[0], diff[1]) * 180 / math.pi
-
-                    if startrot == None:
-                        startrot = rotation
-                        rotation = 0
-                    else:
-                        rotation -= startrot - 360
-
-                    x = coords[0] * clip.size[0]
-                    y = (1 - coords[1]) * clip.size[1]
-
-                    data.append([marker.frame, x, y, xscale, yscale, rotation])
-
-                posline = "\t{0}\t{1:.3f}\t{2:.3f}\t0"
-                scaleline = "\t{0}\t{1:.3f}\t{2:.3f}\t100"
-                rotline = "\t{0}\t{1:.3f}"
-
-                positions = "\r\n".join([posline.format(d[0], d[1], d[2]) for d in data]) + "\r\n\r\n"
-                scales = "\r\n".join([scaleline.format(d[0], d[3], d[4]) for d in data]) + "\r\n\r\n"
-                rotations = "\r\n".join([rotline.format(d[0], d[5]) for d in data]) + "\r\n\r\n"
-
-                f.write("Anchor Point\r\n")
-                f.write("\tFrame\tX pixels\tY pixels\tZ pixels\r\n")
-                f.write(positions)
-
-                f.write("Position\r\n")
-                f.write("\tFrame\tX pixels\tY pixels\tZ pixels\r\n")
-                f.write(positions)
-
-                f.write("Scale\r\n")
-                f.write("\tFrame\tX percent\tY percent\tZ percent\r\n")
-                f.write(scales)
-
-                f.write("Rotation\r\n")
-                f.write("\tFrame Degrees\r\n")
-                f.write(rotations)
-
-                f.write("End of Keyframe Data\r\n")
-
-    return {'FINISHED'}
-
-from bpy_extras.io_utils import ExportHelper
-from bpy.props import StringProperty
-
-class ExportAFXKey(bpy.types.Operator, ExportHelper):
-    """Export motion tracking markers to Adobe After Effects 6.0 compatible files"""
-    bl_idname = "export.afxkey"
-    bl_label = "Export to Adobe After Effects 6.0 Keyframe Data"
-    filename_ext = ""
-    filter_glob = StringProperty(default="*", options={'HIDDEN'})
+class AAEExportExportAll(bpy.types.Operator):
+    bl_label = "Export"
+    bl_description = "Export all tracking markers and plane tracks to AAE files next to the original movie clip"
+    bl_idname = "movieclip.aae_export_export_all"
 
     def execute(self, context):
-        return write_files(self.filepath, context)
+        clip = context.edit_movieclip
+        settings = context.screen.AAEExportSettings
 
-classes = (
-    ExportAFXKey,
-)
+        for track in clip.tracking.tracks:
+            AAEExportExportAll._export_to_file(clip, track, AAEExportExportAll._generate(clip, track), None, settings.do_do_not_overwrite)
 
-def menu_func_export(self, context):
-    self.layout.operator(ExportAFXKey.bl_idname, text="Adobe After Effects 6.0 Keyframe Data")
+        for plane_track in clip.tracking.plane_tracks:
+            AAEExportExportAll._export_to_file(clip, plane_track, AAEExportExportAll._generate(clip, plane_track), None, settings.do_do_not_overwrite)
+        
+        return {'FINISHED'}
 
+    @staticmethod
+    def _generate(clip, track):
+        """
+        Parameters
+        ----------
+        clip : bpy.types.MovieClip
+        track : bpy.types.MovieTrackingTrack or MovieTrackingPlaneTrack
+
+        Returns
+        -------
+        aae : str
+
+        """
+        startarea = None
+        startwidth = None
+        startheight = None
+        startrot = None
+
+        data = []
+
+        aae = "Adobe After Effects 6.0 Keyframe Data\n\n"
+        aae += "\tUnits Per Second\t{0:.3f}\n".format(clip.fps)
+        aae += "\tSource Width\t{0}\n".format(clip.size[0])
+        aae += "\tSource Height\t{0}\n".format(clip.size[1])
+        aae += "\tSource Pixel Aspect Ratio\t1\n"
+        aae += "\tComp Pixel Aspect Ratio\t1\n\n"
+
+        for marker in track.markers:
+            if not 0 < marker.frame <= clip.frame_duration:
+                continue
+            if marker.mute:
+                continue
+
+            if marker.__class__.__name__ == "MovieTrackingMarker":
+                coords = marker.co
+                corners = marker.pattern_corners
+            else: # "MovieTrackingPlaneMarker"
+                c = marker.corners
+                coords = mathutils.geometry.intersect_line_line_2d(c[0], c[2], c[1], c[3])
+                corners = [mathutils.Vector(p) - coords for p in c]
+            
+            area = 0
+            width = math.sqrt((corners[1][0] - corners[0][0]) * (corners[1][0] - corners[0][0]) + (corners[1][1] - corners[0][1]) * (corners[1][1] - corners[0][1]))
+            height = math.sqrt((corners[3][0] - corners[0][0]) * (corners[3][0] - corners[0][0]) + (corners[3][1] - corners[0][1]) * (corners[3][1] - corners[0][1]))
+            for i in range(1,3):
+                x1 = corners[i][0] - corners[0][0]
+                y1 = corners[i][1] - corners[0][1]
+                x2 = corners[i+1][0] - corners[0][0]
+                y2 = corners[i+1][1] - corners[0][1]
+                area += x1 * y2 - x2 * y1
+            
+            area = abs(area / 2)
+
+            if startarea == None:
+                startarea = area
+
+            if startwidth == None:
+                startwidth = width
+            if startheight == None:
+                startheight = height
+
+            zoom = math.sqrt(area / startarea) * 100
+
+            xscale = width / startwidth * 100
+            yscale = height / startheight * 100
+
+            p1 = mathutils.Vector(corners[0])
+            p2 = mathutils.Vector(corners[1])
+            mid = (p1 + p2) / 2
+            diff = mid - mathutils.Vector((0,0))
+
+            rotation = math.atan2(diff[0], diff[1]) * 180 / math.pi
+
+            if startrot == None:
+                startrot = rotation
+                rotation = 0
+            else:
+                rotation -= startrot - 360
+
+            x = coords[0] * clip.size[0]
+            y = (1 - coords[1]) * clip.size[1]
+
+            data.append([marker.frame, x, y, xscale, yscale, rotation])
+
+        posline = "\t{0}\t{1:.3f}\t{2:.3f}\t0"
+        scaleline = "\t{0}\t{1:.3f}\t{2:.3f}\t100"
+        rotline = "\t{0}\t{1:.3f}"
+
+        positions = "\n".join([posline.format(d[0], d[1], d[2]) for d in data]) + "\n\n"
+        scales = "\n".join([scaleline.format(d[0], d[3], d[4]) for d in data]) + "\n\n"
+        rotations = "\n".join([rotline.format(d[0], d[5]) for d in data]) + "\n\n"
+
+        aae += "Anchor Point\n"
+        aae += "\tFrame\tX pixels\tY pixels\tZ pixels\n"
+        aae += positions
+
+        aae += "Position\n"
+        aae += "\tFrame\tX pixels\tY pixels\tZ pixels\n"
+        aae += positions
+
+        aae += "Scale\n"
+        aae += "\tFrame\tX percent\tY percent\tZ percent\n"
+        aae += scales
+
+        aae += "Rotation\n"
+        aae += "\tFrame Degrees\n"
+        aae += rotations
+
+        aae += "End of Keyframe Data\n"
+
+        return aae
+
+    @staticmethod
+    def _export_to_file(clip, track, aae, prefix, do_do_not_overwrite):
+        """
+        Parameters
+        ----------
+        clip : bpy.types.MovieClip
+        track : bpy.types.MovieTrackingTrack or MovieTrackingPlaneTrack
+        aae : str
+            Likely coming from _generated().
+        prefix : None or str
+        do_do_not_overwrite : bool
+            AAEExportSettings.do_do_not_overwrite.
+
+        """
+        coords = None
+        if track.markers[0].__class__.__name__ == "MovieTrackingMarker":
+            for marker in track.markers:
+                if not marker.mute:
+                    coords = (marker.co[0] * clip.size[0], (1 - marker.co[1]) * clip.size[1])
+                    break
+        else: # "MovieTrackingPlaneMarker"
+            for marker in track.markers:
+                if not marker.mute:
+                    coords = mathutils.geometry.intersect_line_line_2d(marker.corners[0], marker.corners[2], marker.corners[1], marker.corners[3])
+                    coords = (coords[0] * clip.size[0], (1 - coords[1]) * clip.size[1])
+                    break
+
+        if coords != None:
+            p = Path(clip.filepath if not prefix else prefix)
+            p = p.with_stem(p.stem + \
+                            "[" + ("Track" if track.markers[0].__class__.__name__ == "MovieTrackingMarker" else "Plane Track") + "]" + \
+                            f"[({coords[0]:.0f}, {coords[1]:.0f})]" + \
+                            (datetime.now().strftime("[%H%M%S %b %d]") if do_do_not_overwrite else "")) \
+                 .with_suffix(".txt")
+            with p.open(mode="w", encoding="utf-8", newline="\r\n") as f:
+                f.write(aae)
+
+    @staticmethod
+    def _copy_to_clipboard(context, aae):
+        """
+        Parameters
+        ----------
+        context : bpy.context
+        aae : str
+            Likely coming from _generated().
+            
+        """
+        context.window_manager.clipboard = aae
+
+class AAEExportCopySingleTrack(bpy.types.Operator):
+    bl_label = "Copy"
+    bl_description = "Copy selected marker as AAE data to clipboard"
+    bl_idname = "movieclip.aae_export_copy_single_track"
+
+    def execute(self, context):
+        clip = context.edit_movieclip
+        settings = context.screen.AAEExportSettings
+
+        aae = AAEExportExportAll._generate(clip, context.selected_movieclip_tracks[0])
+        
+        AAEExportExportAll._copy_to_clipboard(context, aae)
+        if settings.do_also_export:
+            AAEExportExportAll._export_to_file(clip, context.selected_movieclip_tracks[0], aae, None, settings.do_do_not_overwrite)
+        
+        return {'FINISHED'}
+
+class AAEExportCopyPlaneTrack(bpy.types.Operator):
+    bl_label = "Copy"
+    bl_description = "Copy selected plane track as AAE data to clipboard"
+    bl_idname = "movieclip.aae_export_copy_plane_track"
+
+    def execute(self, context):
+        clip = context.edit_movieclip
+        settings = context.screen.AAEExportSettings
+
+        aae = AAEExportExportAll._generate(clip, clip.tracking.plane_tracks[0])
+
+        AAEExportExportAll._copy_to_clipboard(context, aae)
+        if settings.do_also_export:
+            AAEExportExportAll._export_to_file(clip, clip.tracking.plane_tracks[0], aae, None, settings.do_do_not_overwrite)
+        
+        return {'FINISHED'}
+    
+class AAEExport(bpy.types.Panel):
+    bl_label = "AAE Export"
+    bl_idname = "SOLVE_PT_aae_export"
+    bl_space_type = "CLIP_EDITOR"
+    bl_region_type = "TOOLS"
+    bl_category = "Solve"
+
+    def draw(self, context):
+        pass
+
+class AAEExportSelectedTrack(bpy.types.Panel):
+    bl_label = "Selected track"
+    bl_idname = "SOLVE_PT_aae_export_selected"
+    bl_space_type = "CLIP_EDITOR"
+    bl_region_type = "TOOLS"
+    bl_category = "Solve"
+    bl_parent_id = "SOLVE_PT_aae_export"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        
+        settings = context.screen.AAEExportSettings
+        
+        column = layout.column()
+        column.label(text="Selected track")
+
+        row = layout.row()
+        row.scale_y = 2
+        row.enabled = len(context.selected_movieclip_tracks) == 1
+        row.operator("movieclip.aae_export_copy_single_track")
+        
+        column = layout.column()
+        column.label(text="Selected plane track")
+        
+        selected_plane_tracks = 0
+        for plane_track in context.edit_movieclip.tracking.plane_tracks:
+            if plane_track.select == True:
+                selected_plane_tracks += 1
+
+        row = layout.row()
+        row.scale_y = 2
+        row.enabled = selected_plane_tracks == 1
+        row.operator("movieclip.aae_export_copy_plane_track")
+
+class AAEExportAllTracks(bpy.types.Panel):
+    bl_label = "All tracks"
+    bl_idname = "SOLVE_PT_aae_export_all"
+    bl_space_type = "CLIP_EDITOR"
+    bl_region_type = "TOOLS"
+    bl_category = "Solve"
+    bl_parent_id = "SOLVE_PT_aae_export"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        
+        settings = context.screen.AAEExportSettings
+        
+        column = layout.column()
+        column.label(text="All tracks")
+        column.prop(settings, "do_also_export")
+        column.prop(settings, "do_do_not_overwrite")
+        
+        row = layout.row()
+        row.scale_y = 2
+        row.enabled = len(context.edit_movieclip.tracking.tracks) >= 1
+        row.operator("movieclip.aae_export_export_all")
+
+class AAEExportLegacy(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
+    """Export motion tracking markers to Adobe After Effects 6.0 compatible files"""
+    bl_label = "Export to Adobe After Effects 6.0 Keyframe Data"
+    bl_idname = "export.aae_export_legacy"
+    filename_ext = ""
+    filter_glob = bpy.props.StringProperty(default="*", options={'HIDDEN'})
+
+    def execute(self, context):
+        # This is broken but I don't want to fix...
+        if len(bpy.data.movieclips) != 1:
+            raise ValueError("The legacy export method only allows one clip to be loaded into Blender at a time. You can either try the new export interface at „Clip Editor > Tools > Solve > AAE Export“ or use „File > New“ to create a new Blender file.")
+        clip = bpy.data.movieclips[0]
+        settings = context.screen.AAEExportSettings
+
+        for track in clip.tracking.tracks:
+            AAEExportExportAll._export_to_file(clip, track, AAEExportExportAll._generate(clip, track), self.filepath, settings.do_do_not_overwrite)
+
+        for plane_track in clip.tracking.plane_tracks:
+            AAEExportExportAll._export_to_file(clip, track, AAEExportExportAll._generate(clip, plane_track), self.filepath, settings.do_do_not_overwrite)
+
+classes = (AAEExportSettings,
+           AAEExportExportAll,
+           AAEExportCopySingleTrack,
+           AAEExportCopyPlaneTrack,
+           AAEExport,
+           AAEExportSelectedTrack,
+           AAEExportAllTracks,
+           AAEExportLegacy)
+           
+def register_export_legacy(self, context):
+    self.layout.operator(AAEExportLegacy.bl_idname, text="Adobe After Effects 6.0 Keyframe Data")
 
 def register():
-    from bpy.utils import register_class
-    for cls in classes:
-        register_class(cls)
-    bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
+    for class_ in classes:
+        bpy.utils.register_class(class_)
+        
+    bpy.types.Screen.AAEExportSettings = bpy.props.PointerProperty(type=AAEExportSettings)
+        
+    bpy.types.TOPBAR_MT_file_export.append(register_export_legacy)
 
 def unregister():
-    from bpy.utils import unregister_class
-    for cls in reversed(classes):
-        unregister_class(cls)
-    bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
+    bpy.types.TOPBAR_MT_file_export.remove(register_export_legacy)
+    
+    del bpy.types.Screen.AAEExportSettings
+    
+    for class_ in classes:
+        bpy.utils.unregister_class(class_)
 
 if __name__ == "__main__":
     register()
+#    unregister() 

--- a/scripts/aae-export.py
+++ b/scripts/aae-export.py
@@ -58,7 +58,7 @@ class AAEExportExportAll(bpy.types.Operator):
         for plane_track in clip.tracking.plane_tracks:
             AAEExportExportAll._export_to_file(clip, plane_track, AAEExportExportAll._generate(clip, plane_track), None, settings.do_do_not_overwrite)
         
-        return {'FINISHED'}
+        return {"FINISHED"}
 
     @staticmethod
     def _generate(clip, track):
@@ -236,7 +236,7 @@ class AAEExportCopySingleTrack(bpy.types.Operator):
         if settings.do_also_export:
             AAEExportExportAll._export_to_file(clip, context.selected_movieclip_tracks[0], aae, None, settings.do_do_not_overwrite)
         
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 class AAEExportCopyPlaneTrack(bpy.types.Operator):
     bl_label = "Copy"
@@ -253,7 +253,7 @@ class AAEExportCopyPlaneTrack(bpy.types.Operator):
         if settings.do_also_export:
             AAEExportExportAll._export_to_file(clip, clip.tracking.plane_tracks[0], aae, None, settings.do_do_not_overwrite)
         
-        return {'FINISHED'}
+        return {"FINISHED"}
     
 class AAEExport(bpy.types.Panel):
     bl_label = "AAE Export"
@@ -331,7 +331,8 @@ class AAEExportAllTracks(bpy.types.Panel):
         
         row = layout.row()
         row.scale_y = 2
-        row.enabled = len(context.edit_movieclip.tracking.tracks) >= 1
+        row.enabled = len(context.edit_movieclip.tracking.tracks) >= 1 or \
+                      len(context.edit_movieclip.tracking.plane_tracks) >= 1
         row.operator("movieclip.aae_export_export_all")
 
     @classmethod
@@ -343,7 +344,7 @@ class AAEExportLegacy(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
     bl_label = "Export to Adobe After Effects 6.0 Keyframe Data"
     bl_idname = "export.aae_export_legacy"
     filename_ext = ""
-    filter_glob = bpy.props.StringProperty(default="*", options={'HIDDEN'})
+    filter_glob = bpy.props.StringProperty(default="*", options={"HIDDEN"})
 
     def execute(self, context):
         # This is broken but I don't want to fix...

--- a/scripts/aae-export.py
+++ b/scripts/aae-export.py
@@ -399,10 +399,10 @@ class AAEExportLegacy(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         settings = context.screen.AAEExportSettings
 
         for track in clip.tracking.tracks:
-            AAEExportExportAll._export_to_file(clip, track, AAEExportExportAll._generate(clip, track), self.filepath, settings.do_do_not_overwrite)
+            AAEExportExportAll._export_to_file(clip, track, AAEExportExportAll._generate(clip, track), self.filepath, True)
 
         for plane_track in clip.tracking.plane_tracks:
-            AAEExportExportAll._export_to_file(clip, track, AAEExportExportAll._generate(clip, plane_track), self.filepath, settings.do_do_not_overwrite)
+            AAEExportExportAll._export_to_file(clip, track, AAEExportExportAll._generate(clip, plane_track), self.filepath, True)
 
 classes = (AAEExportSettings,
            AAEExportExportAll,

--- a/scripts/aae-export.py
+++ b/scripts/aae-export.py
@@ -465,8 +465,10 @@ class AAEExportLegacy(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
     filter_glob = bpy.props.StringProperty(default="*", options={"HIDDEN"})
 
     def execute(self, context):
+        if len(bpy.data.movieclips) == 0:
+            raise ValueError("Have you opened any movie clips?")
         # This is broken but I don't want to fix...
-        if len(bpy.data.movieclips) != 1:
+        if len(bpy.data.movieclips) >= 2:
             raise ValueError("The legacy export method only allows one clip to be loaded into Blender at a time. You can either try the new export interface at „Clip Editor > Tools > Solve > AAE Export“ or use „File > New“ to create a new Blender file.")
         clip = bpy.data.movieclips[0]
         settings = context.screen.AAEExportSettings
@@ -476,6 +478,8 @@ class AAEExportLegacy(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
 
         for plane_track in clip.tracking.plane_tracks:
             AAEExportExportAll._export_to_file(clip, track, AAEExportExportAll._generate(clip, plane_track, False), self.filepath, True)
+
+        return {"FINISHED"}
 
 classes = (AAEExportSettings,
            AAEExportExportAll,

--- a/scripts/powerpin-export.py
+++ b/scripts/powerpin-export.py
@@ -73,10 +73,10 @@ class PowerPinExportExport(bpy.types.Operator):
         else:
             do_copy_to_clipboard = settings.do_copy_to_clipboard
 
-        if plane_tracks > 1 and len(selected_plane_tracks) != plane_tracks and len(selected_plane_tracks) != 0:
-            plane_tracks = selected_plane_tracks # Same as above
+        if plane_tracks > 1 and len(selected_plane_tracks) != 0:
+            plane_tracks = selected_plane_tracks # Confusion
         else:
-            plane_tracks = clip.tracking.plane_tracks # Same ww
+            plane_tracks = clip.tracking.plane_tracks
 
         for plane_track in plane_tracks:
             power_pin = PowerPinExportExport._generate(clip, plane_track)

--- a/scripts/powerpin-export.py
+++ b/scripts/powerpin-export.py
@@ -1,88 +1,271 @@
+# Copyright (c) 2022 arch1t3cht
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+# 
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 bl_info = {
-    "name": "Export: Adobe After Effects 6.0 Keyframe Data (Power Pin)",
-    "description": "Export a plane track to Adobe After Effects 6.0 compatible files",
-    "author": "arch1t3cht",
-    "version": (0, 1, 0),
+    "name": "Adobe After Effects 6.0 Keyframe Data Export (Power Pin)",
+    "description": "Export plane track to Aegisub-Motion compatible AAE file",
+    "author": "arch1t3cht, Akatsumekusa",
+    "version": (0, 1, 1),
+    "support": "COMMUNITY",
+    "category": "Video Tools",
     "blender": (3, 2, 0),
-    "location": "File > Export > Adobe After Effects 6.0 Keyframe Data (Power Pin)",
+    "location": "Clip Editor > Tools > Solve > AAE Export (Power Pin)",
     "warning": "",
-    "category": "Import-Export",
+    "doc_url": "https://github.com/arch1t3cht/Aegisub-Scripts#other-scripts",
+    "tracker_url": "https://github.com/arch1t3cht/Aegisub-Scripts/issues"
 }
 
 import itertools
 import bpy
+import bpy_extras.io_utils
+from datetime import datetime
+import mathutils.geometry
+from pathlib import Path
 
-dataname = bl_info["location"].split(" > ")[2]
+class PowerPinExportSettings(bpy.types.PropertyGroup):
+    bl_label = "PowerPinExportSettings"
+    bl_idname = "PowerPinExportSettings"
+    
+    do_do_not_overwrite: bpy.props.BoolProperty(name="Do not overwrite",
+                                                description="Generate unique files every time",
+                                                default=False)
+    do_copy_to_clipboard: bpy.props.BoolProperty(name="Copy to clipboard",
+                                                 description="Copy the Power Pin data to clipboard.\nThis will only work either when there is only one plane track on the clip, or there is only one plane track selected",
+                                                 default=True)
 
-def corners_from_marker(marker):
-    if marker.__class__.__name__ == "MovieTrackingPlaneMarker":
-        return [list(c) for c in marker.corners]
-    elif marker.__class__.__name__ == "MovieTrackingMarker":
-        return [[marker.co[i] + cv for i, cv in enumerate(c)] for c in marker.pattern_corners]
-
-
-def write_files(prefix, context):
-    scene = context.scene
-    fps = scene.render.fps / scene.render.fps_base
-
-    for clipno, clip in enumerate(bpy.data.movieclips):
-        for trackno, track in itertools.chain(enumerate(clip.tracking.tracks), enumerate(clip.tracking.plane_tracks)):
-            with open("{0}_c{1:02d}_{3}{2:02d}_{4}.txt".format(prefix, clipno, trackno, "planetrack" if track.__class__.__name__ == "MovieTrackingPlaneTrack" else "track", track.name.lower().replace(" ", "_")), "w") as f:
-                f.write("Adobe After Effects 6.0 Keyframe Data\n\n")
-                f.write("\tUnits Per Second\t{0:.3f}\n".format(fps))
-                f.write("\tSource Width\t{0}\n".format(clip.size[0]))
-                f.write("\tSource Height\t{0}\n".format(clip.size[1]))
-                f.write("\tSource Pixel Aspect Ratio\t1\n")
-                f.write("\tComp Pixel Aspect Ratio\t1\n")
-
-                corners = [corners_from_marker(track.markers.find_frame(frameno)) for frameno in range(clip.frame_start, clip.frame_start + clip.frame_duration)]
-
-                for pini, corneri in [(2, 3), (3, 2), (4, 0), (5, 1)]:
-                    f.write(f"\nEffects\tCC Power Pin #1\tCC Power Pin-000{pini}\n")
-                    f.write("\tFrame\tX pixels\tY pixels\n")
-
-                    for i, plane in enumerate(corners):
-                        corner = plane[corneri]
-                        x = corner[0] * clip.size[0]
-                        y = (1 - corner[1]) * clip.size[1]
-                        f.write(f"\t{i}\t{x:.3f}\t{y:.3f}\n")
-
-                f.write("\nEnd of Keyframe Data\n")
-
-    return {'FINISHED'}
-
-from bpy_extras.io_utils import ExportHelper
-from bpy.props import StringProperty
-
-class ExportAFXPP(bpy.types.Operator, ExportHelper):
-    """Export a plane track to Adobe After Effects 6.0 compatible files"""
-    bl_idname = "export.afxpp"
-    bl_label = f"Export to {dataname}"
-    filename_ext = ""
-    filter_glob = StringProperty(default="*", options={'HIDDEN'})
+class PowerPinExportExport(bpy.types.Operator):
+    bl_label = "Export"
+    bl_description = "Export plane track to Power Pin AAE files next to the original movie clip"
+    bl_idname = "movieclip.power_pin_export_export"
 
     def execute(self, context):
-        return write_files(self.filepath, context)
+        clip = context.edit_movieclip
+        settings = context.screen.PowerPinExportSettings
 
-classes = (
-    ExportAFXPP,
-)
+        plane_tracks = 0 # Please enjoy the confusion
+        selected_plane_tracks = []
+        for plane_track in context.edit_movieclip.tracking.plane_tracks:
+            plane_tracks += 1
+            if plane_track.select == True:
+                selected_plane_tracks.append(plane_track)
 
-def menu_func_export(self, context):
-    self.layout.operator(ExportAFXPP.bl_idname, text=dataname)
+        if plane_tracks > 1 and len(selected_plane_tracks) != 1:
+            do_copy_to_clipboard = False
+        else:
+            do_copy_to_clipboard = settings.do_copy_to_clipboard
 
+        if plane_tracks > 1 and len(selected_plane_tracks) != plane_tracks and len(selected_plane_tracks) != 0:
+            plane_tracks = selected_plane_tracks # Same as above
+        else:
+            plane_tracks = clip.tracking.plane_tracks # Same ww
+
+        for plane_track in plane_tracks:
+            power_pin = PowerPinExportExport._generate(clip, plane_track)
+
+            if do_copy_to_clipboard:
+                PowerPinExportExport._copy_to_clipboard(context, power_pin)
+            PowerPinExportExport._export_to_file(clip, plane_track, power_pin, None, settings.do_do_not_overwrite)
+        
+        return {'FINISHED'}
+
+    @staticmethod
+    def _generate(clip, track):
+        """
+        Parameters
+        ----------
+        clip : bpy.types.MovieClip
+        track : bpy.types.MovieTrackingTrack or MovieTrackingPlaneTrack
+
+        Returns
+        -------
+        power_pin : str
+        """
+        power_pin = "Adobe After Effects 6.0 Keyframe Data\n\n"
+        power_pin += "\tUnits Per Second\t{0:.3f}\n".format(clip.fps)
+        power_pin += "\tSource Width\t{0}\n".format(clip.size[0])
+        power_pin += "\tSource Height\t{0}\n".format(clip.size[1])
+        power_pin += "\tSource Pixel Aspect Ratio\t1\n"
+        power_pin += "\tComp Pixel Aspect Ratio\t1\n"
+
+        frames = []
+        corners = []
+        for marker in track.markers:
+            if not 0 < marker.frame <= clip.frame_duration:
+                continue
+            if marker.mute:
+                continue
+
+            frames.append(marker.frame)
+            corners.append([list(c) for c in marker.corners])
+        
+        for pini, corneri in [(2, 3), (3, 2), (4, 0), (5, 1)]:
+            power_pin += f"\nEffects\tCC Power Pin #1\tCC Power Pin-000{pini}\n"
+            power_pin += "\tFrame\tX pixels\tY pixels\n"
+
+            for i, plane in enumerate(corners):
+                corner = plane[corneri]
+                x = corner[0] * clip.size[0]
+                y = (1 - corner[1]) * clip.size[1]
+                power_pin += f"\t{frames[i]}\t{x:.3f}\t{y:.3f}\n"
+
+        power_pin += "\nEnd of Keyframe Data\n"
+
+        return power_pin
+
+    @staticmethod
+    def _export_to_file(clip, track, power_pin, prefix, do_do_not_overwrite):
+        """
+        Parameters
+        ----------
+        clip : bpy.types.MovieClip
+        track : bpy.types.MovieTrackingTrack or MovieTrackingPlaneTrack
+        power_pin : str
+            Likely coming from _generated().
+        prefix : None or str
+        do_do_not_overwrite : bool
+            PowerPinExportSettings.do_do_not_overwrite.
+
+        """
+        coords = None
+        for marker in track.markers:
+            if not marker.mute:
+                coords = mathutils.geometry.intersect_line_line_2d(marker.corners[0], marker.corners[2], marker.corners[1], marker.corners[3])
+                coords = (coords[0] * clip.size[0], (1 - coords[1]) * clip.size[1])
+                break
+
+        if coords != None:
+            p = Path(clip.filepath if not prefix else prefix)
+            p = p.with_stem(p.stem + \
+                            "[Plane Track][Power Pin]" + \
+                            f"[({coords[0]:.0f}, {coords[1]:.0f})]" + \
+                            (datetime.now().strftime("[%H%M%S %b %d]") if do_do_not_overwrite else "")) \
+                 .with_suffix(".txt")
+            with p.open(mode="w", encoding="utf-8", newline="\r\n") as f:
+                f.write(power_pin)
+                
+    @staticmethod
+    def _copy_to_clipboard(context, power_pin):
+        """
+        Parameters
+        ----------
+        context : bpy.context
+        power_pin : str
+            Likely coming from _generated().
+            
+        """
+        context.window_manager.clipboard = power_pin
+
+class PowerPinExport(bpy.types.Panel):
+    bl_label = "AAE Export (PowerPin)"
+    bl_idname = "SOLVE_PT_power_pin_export"
+    bl_space_type = "CLIP_EDITOR"
+    bl_region_type = "TOOLS"
+    bl_category = "Solve"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        
+        settings = context.screen.PowerPinExportSettings
+
+        plane_tracks = 0
+        selected_plane_tracks = 0
+        for plane_track in context.edit_movieclip.tracking.plane_tracks:
+            plane_tracks += 1
+            if plane_track.select == True:
+                selected_plane_tracks += 1
+
+        column = layout.column()
+        if plane_tracks <= 1:
+            column.label(text="Plane track")
+        else:
+            if selected_plane_tracks == 0:
+                column.label(text="Plane track")
+            else:
+                column.label(text="Selected plane track")
+        column.prop(settings, "do_do_not_overwrite")
+        row = column.row()
+        if plane_tracks <= 1:
+            row.enabled = True
+        else:
+            if selected_plane_tracks == 1:
+                row.enabled = True
+            else:
+                row.enabled = False
+        row.prop(settings, "do_copy_to_clipboard")
+        
+        row = layout.row()
+        row.scale_y = 2
+        if plane_tracks == 0:
+            row.enabled = False
+        else:
+            row.enabled = True
+        row.operator("movieclip.power_pin_export_export")
+
+class PowerPinExportLegacy(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
+    """Export a plane track to Adobe After Effects 6.0 compatible files"""
+    bl_label = "Export to Adobe After Effects 6.0 Keyframe Data (Power Pin)"
+    bl_idname = "export.power_pin_export_legacy"
+    filename_ext = ""
+    filter_glob = bpy.props.StringProperty(default="*", options={'HIDDEN'})
+
+    def execute(self, context):
+        # This is broken but I don't want to fix...
+        if len(bpy.data.movieclips) != 1:
+            raise ValueError("The legacy export method only allows one clip to be loaded into Blender at a time. You can either try the new export interface at „Clip Editor > Tools > Solve > AAE Export (Power Pin)“ or use „File > New“ to create a new Blender file.")
+        clip = bpy.data.movieclips[0]
+        settings = context.screen.PowerPinExportSettings
+
+        for plane_track in clip.tracking.plane_tracks:
+            PowerPinExportExport._export_to_file(clip, track, PowerPinExportExport._generate(clip, plane_track), self.filepath, settings.do_do_not_overwrite)     
+
+classes = (PowerPinExportSettings,
+           PowerPinExportExport,
+           PowerPinExport,
+           PowerPinExportLegacy)
+           
+def register_export_legacy(self, context):
+    self.layout.operator(PowerPinExportLegacy.bl_idname, text="Adobe After Effects 6.0 Keyframe Data (Power Pin)")
 
 def register():
-    from bpy.utils import register_class
-    for cls in classes:
-        register_class(cls)
-    bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
+    for class_ in classes:
+        bpy.utils.register_class(class_)
+        
+    bpy.types.Screen.PowerPinExportSettings = bpy.props.PointerProperty(type=PowerPinExportSettings)
+        
+    bpy.types.TOPBAR_MT_file_export.append(register_export_legacy)
 
 def unregister():
-    from bpy.utils import unregister_class
-    for cls in reversed(classes):
-        unregister_class(cls)
-    bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
+    bpy.types.TOPBAR_MT_file_export.remove(register_export_legacy)
+    
+    del bpy.types.Screen.PowerPinExportSettings
+    
+    for class_ in classes:
+        bpy.utils.unregister_class(class_)
 
 if __name__ == "__main__":
     register()
+#    unregister() 
+
+
+

--- a/scripts/powerpin-export.py
+++ b/scripts/powerpin-export.py
@@ -49,7 +49,7 @@ class PowerPinExportSettings(bpy.types.PropertyGroup):
                                                 description="Generate unique files every time",
                                                 default=False)
     do_copy_to_clipboard: bpy.props.BoolProperty(name="Copy to clipboard",
-                                                 description="Copy the Power Pin data to clipboard.\nThis will only work either when there is only one plane track on the clip, or there is only one plane track selected",
+                                                 description="Copy the Power Pin data to clipboard.\nThis option will only work either when there is only one plane track on the clip, or there is only one plane track selected",
                                                  default=True)
 
 class PowerPinExportExport(bpy.types.Operator):

--- a/scripts/powerpin-export.py
+++ b/scripts/powerpin-export.py
@@ -175,7 +175,7 @@ class PowerPinExportExport(bpy.types.Operator):
         context.window_manager.clipboard = power_pin
 
 class PowerPinExport(bpy.types.Panel):
-    bl_label = "AAE Export (PowerPin)"
+    bl_label = "AAE Export (Power Pin)"
     bl_idname = "SOLVE_PT_power_pin_export"
     bl_space_type = "CLIP_EDITOR"
     bl_region_type = "TOOLS"

--- a/scripts/powerpin-export.py
+++ b/scripts/powerpin-export.py
@@ -241,12 +241,14 @@ class PowerPinExport(bpy.types.Panel):
 
         column = layout.column()
         if plane_tracks <= 1:
-            column.label(text="Plane track")
+            column.label(text="Plane tracks")
         else:
             if selected_plane_tracks == 0:
-                column.label(text="Plane track")
-            else:
+                column.label(text="Plane tracks")
+            elif selected_plane_tracks == 1:
                 column.label(text="Selected plane track")
+            else:
+                column.label(text="Selected plane tracks")
         column.prop(settings, "do_do_not_overwrite")
         row = column.row()
         if plane_tracks <= 1:

--- a/scripts/powerpin-export.py
+++ b/scripts/powerpin-export.py
@@ -222,6 +222,10 @@ class PowerPinExport(bpy.types.Panel):
             row.enabled = True
         row.operator("movieclip.power_pin_export_export")
 
+    @classmethod
+    def poll(cls, context):
+        return context.edit_movieclip is not None
+
 class PowerPinExportLegacy(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
     """Export a plane track to Adobe After Effects 6.0 compatible files"""
     bl_label = "Export to Adobe After Effects 6.0 Keyframe Data (Power Pin)"

--- a/scripts/powerpin-export.py
+++ b/scripts/powerpin-export.py
@@ -85,7 +85,7 @@ class PowerPinExportExport(bpy.types.Operator):
                 PowerPinExportExport._copy_to_clipboard(context, power_pin)
             PowerPinExportExport._export_to_file(clip, plane_track, power_pin, None, settings.do_do_not_overwrite)
         
-        return {'FINISHED'}
+        return {"FINISHED"}
 
     @staticmethod
     def _generate(clip, track):
@@ -231,7 +231,7 @@ class PowerPinExportLegacy(bpy.types.Operator, bpy_extras.io_utils.ExportHelper)
     bl_label = "Export to Adobe After Effects 6.0 Keyframe Data (Power Pin)"
     bl_idname = "export.power_pin_export_legacy"
     filename_ext = ""
-    filter_glob = bpy.props.StringProperty(default="*", options={'HIDDEN'})
+    filter_glob = bpy.props.StringProperty(default="*", options={"HIDDEN"})
 
     def execute(self, context):
         # This is broken but I don't want to fix...
@@ -270,6 +270,3 @@ def unregister():
 if __name__ == "__main__":
     register()
 #    unregister() 
-
-
-


### PR DESCRIPTION
### *\[Ready to merge after #6\]*

## Changelog

* Merge Power Pin functionality into `aae-export.py`.  
Currently, a-mo functions correctly with extra Power Pin data, but persp-mo doesn't work when Power Pin data is mixed with regular tracking data. This is likely caused by a bug in persp-mo. It makes this feature not usable at the moment.  
However, since this feature doesn't pose any harm to current workflow, I want to implement it first and wait for persp-mo to support it.  
* License changed to dual-licensed ISC License + MIT License for the whole `aae-export.py`.  

### Screenshots

![image](https://user-images.githubusercontent.com/112813970/201458340-daea0e71-1789-40e8-9812-036c4c13a29b.png)  

Thank you.  